### PR TITLE
Prefix the APP_ENV

### DIFF
--- a/src/Commands/BranchDeployForgeCommand.php
+++ b/src/Commands/BranchDeployForgeCommand.php
@@ -178,7 +178,7 @@ class BranchDeployForgeCommand extends Command
     {
         $this->output('Updating site environment variables');
         $envSource = $this->forge->siteEnvironmentFile($server->id, $site->id);
-        $envSource = $this->updateEnvVariable('APP_ENV', 'th-' . $this->getBranch(), $envSource);
+        $envSource = $this->updateEnvVariable('APP_ENV', 'th-' . $this->getFullEnvName(), $envSource);
         $envSource = $this->updateEnvVariable('LOCAL_DEVELOPER', $this->getBranch(), $envSource);
         $envSource = $this->updateEnvVariable('APP_URL', 'https://' . $this->generateOpsDomain(), $envSource);
         $envSource = $this->updateEnvVariable('BP_APP_URL', 'https://' . $this->getFrontendDomain(), $envSource);

--- a/src/Commands/BranchDeployForgeCommand.php
+++ b/src/Commands/BranchDeployForgeCommand.php
@@ -176,10 +176,13 @@ class BranchDeployForgeCommand extends Command
 
     protected function updateEnvFile(Server $server, Site $site): void
     {
+        $branch = $this->getBranch();
+        $appEnv = in_array(strtolower($branch), ['main', 'production']) ? $branch : 'th-' . $branch;
+
         $this->output('Updating site environment variables');
         $envSource = $this->forge->siteEnvironmentFile($server->id, $site->id);
-        $envSource = $this->updateEnvVariable('APP_ENV', 'th-' . $this->getBranch(), $envSource);
-        $envSource = $this->updateEnvVariable('LOCAL_DEVELOPER', $this->getBranch(), $envSource);
+        $envSource = $this->updateEnvVariable('APP_ENV', $appEnv, $envSource);
+        $envSource = $this->updateEnvVariable('LOCAL_DEVELOPER', $branch, $envSource);
         $envSource = $this->updateEnvVariable('APP_URL', 'https://' . $this->generateOpsDomain(), $envSource);
         $envSource = $this->updateEnvVariable('BP_APP_URL', 'https://' . $this->getFrontendDomain(), $envSource);
         $envSource = $this->updateEnvVariable('SANCTUM_STATEFUL_DOMAINS', $this->getFrontendDomain() . ',' . $this->generateOpsDomain(), $envSource);

--- a/src/Commands/BranchDeployForgeCommand.php
+++ b/src/Commands/BranchDeployForgeCommand.php
@@ -178,7 +178,7 @@ class BranchDeployForgeCommand extends Command
     {
         $this->output('Updating site environment variables');
         $envSource = $this->forge->siteEnvironmentFile($server->id, $site->id);
-        $envSource = $this->updateEnvVariable('APP_ENV', 'th-' . $this->getBranch(), $envSource);
+        $envSource = $this->updateEnvVariable('APP_ENV', $this->getFullEnvName(), $envSource);
         $envSource = $this->updateEnvVariable('LOCAL_DEVELOPER', $this->getBranch(), $envSource);
         $envSource = $this->updateEnvVariable('APP_URL', 'https://' . $this->generateOpsDomain(), $envSource);
         $envSource = $this->updateEnvVariable('BP_APP_URL', 'https://' . $this->getFrontendDomain(), $envSource);

--- a/src/Commands/BranchDeployForgeCommand.php
+++ b/src/Commands/BranchDeployForgeCommand.php
@@ -176,13 +176,10 @@ class BranchDeployForgeCommand extends Command
 
     protected function updateEnvFile(Server $server, Site $site): void
     {
-        $branch = $this->getBranch();
-        $appEnv = in_array(strtolower($branch), ['main', 'production']) ? $branch : 'th-' . $branch;
-
         $this->output('Updating site environment variables');
         $envSource = $this->forge->siteEnvironmentFile($server->id, $site->id);
-        $envSource = $this->updateEnvVariable('APP_ENV', $appEnv, $envSource);
-        $envSource = $this->updateEnvVariable('LOCAL_DEVELOPER', $branch, $envSource);
+        $envSource = $this->updateEnvVariable('APP_ENV', 'th-' . $this->getBranch(), $envSource);
+        $envSource = $this->updateEnvVariable('LOCAL_DEVELOPER', $this->getBranch(), $envSource);
         $envSource = $this->updateEnvVariable('APP_URL', 'https://' . $this->generateOpsDomain(), $envSource);
         $envSource = $this->updateEnvVariable('BP_APP_URL', 'https://' . $this->getFrontendDomain(), $envSource);
         $envSource = $this->updateEnvVariable('SANCTUM_STATEFUL_DOMAINS', $this->getFrontendDomain() . ',' . $this->generateOpsDomain(), $envSource);

--- a/src/Commands/BranchDeployForgeCommand.php
+++ b/src/Commands/BranchDeployForgeCommand.php
@@ -178,7 +178,7 @@ class BranchDeployForgeCommand extends Command
     {
         $this->output('Updating site environment variables');
         $envSource = $this->forge->siteEnvironmentFile($server->id, $site->id);
-        $envSource = $this->updateEnvVariable('APP_ENV', $this->getBranch(), $envSource);
+        $envSource = $this->updateEnvVariable('APP_ENV', 'th-' . $this->getBranch(), $envSource);
         $envSource = $this->updateEnvVariable('LOCAL_DEVELOPER', $this->getBranch(), $envSource);
         $envSource = $this->updateEnvVariable('APP_URL', 'https://' . $this->generateOpsDomain(), $envSource);
         $envSource = $this->updateEnvVariable('BP_APP_URL', 'https://' . $this->getFrontendDomain(), $envSource);


### PR DESCRIPTION
For PRs that are not `main` or `production`, we will add `th-` prefix to the `APP_ENV` (Forge).

The initial motive is to be able to differ testing environments from production environment on different platforms like "CustomerIO" and other services.

![Screenshot 2024-02-06 at 12 05 34](https://github.com/timberhubcom/laravel-deployments/assets/146819771/b2f3b288-8bf7-42ed-883e-5d2dd5f4567a)
