### PR TITLE
PHP Version Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Use the following command to deploy your application to a Forge server like this
   --repository=[REPOSITORY_URL] \
   --branch=[BRANCH_NAME] \
   --domain=[DOMAIN_NAME] \
+  --php-version=[PHP_VERSION] \
   --db-name=[DB_NAME] \
   --db-user=[DB_USER] \
   --db-password=[DB_PASSWORD]

--- a/src/Commands/BranchDeployForgeCommand.php
+++ b/src/Commands/BranchDeployForgeCommand.php
@@ -35,6 +35,7 @@ class BranchDeployForgeCommand extends Command
             ->addOption('branch', 'b', InputOption::VALUE_REQUIRED, 'The name of the branch being deployed.')
             ->addOption('env-name', 'e', InputOption::VALUE_REQUIRED, 'The name of the env you would like to use.')
             ->addOption('domain', 'd', InputOption::VALUE_OPTIONAL, 'The domain you\'d like to use for deployments.')
+            ->addOption('php-version', 'php-v', InputOption::VALUE_OPTIONAL, 'The PHP version we are creating the env with.', 'php8.1')
             ->addOption('db-name', 'db', InputOption::VALUE_REQUIRED, 'The db name.')
             ->addOption('db-user', 'db-u', InputOption::VALUE_OPTIONAL, 'The db username.')
             ->addOption('db-password', 'db-p', InputOption::VALUE_OPTIONAL, 'The db password.');
@@ -95,7 +96,7 @@ class BranchDeployForgeCommand extends Command
         $this->output('Creating queue');
 
         $data = [
-            'command' => 'php8.1 artisan horizon',
+            'command' => $this->getPhpVersion().' artisan horizon',
             'user' => 'forge',
             'directory' => '/home/forge/'.$this->generateOpsDomain()
         ];

--- a/src/Traits/BranchDeployForgeInputs.php
+++ b/src/Traits/BranchDeployForgeInputs.php
@@ -28,4 +28,9 @@ trait BranchDeployForgeInputs {
     protected function getDatabasePassword(): string {
         return getenv('DB_USER_PASSWORD') ?? $this->input->getOption('db-password');
     }
+
+    protected function getPhpVersion(): string {
+        $version = strtolower($this->input->getOption('php-version'));
+        return in_array($version, ['php8.1', 'php8.2']) ? $version : 'php8.1';
+    }
 }


### PR DESCRIPTION
This PR enables the script to accept the PHP version
It creates a daemon based on the requested version or fallback (8.1).

Context: This change is required for the [Laravel Upgrade](https://www.notion.so/timberhub/Laravel-upgrade-Spike-c729f7ddd31d4fecb240a30f7c893f67?pvs=4)