### PR TITLE
Supabase Env Variables

### DIFF
--- a/src/Commands/BranchDeployForgeCommand.php
+++ b/src/Commands/BranchDeployForgeCommand.php
@@ -232,7 +232,9 @@ class BranchDeployForgeCommand extends Command
         $envSource = $this->updateEnvVariable('DB_DATABASE', $this->getDatabaseName(), $envSource);
         $envSource = $this->updateEnvVariable('DB_USERNAME', $this->getDatabaseUser(), $envSource);
         $envSource = $this->updateEnvVariable('DB_PASSWORD', $this->getDatabasePassword(), $envSource);
-
+        $envSource = $this->updateEnvVariable('SUPABASE_DB_DATABASE', $this->getDatabaseName(), $envSource);
+        $envSource = $this->updateEnvVariable('SUPABASE_DB_USERNAME', $this->getDatabaseUser(), $envSource);
+        $envSource = $this->updateEnvVariable('SUPABASE_DB_PASSWORD', $this->getDatabasePassword(), $envSource);
         $this->forge->updateSiteEnvironmentFile($server->id, $site->id, $envSource);
         $this->output('Site environment variables updated');
     }


### PR DESCRIPTION
As explained [here](https://www.notion.so/timberhub/Fixing-Supabase-Issue-9fe42327831e4edcbc081074ad41f36c?pvs=4#719915d47f4c4c8a8b1ffc14811ffb08) we are going to use the same database to keep catalog-related tables 

(They will be going to a separate schema which is defined by `SUPABASE_DB_SCHEMA` in ops project)